### PR TITLE
Fix typo and update links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ Spherogram
 Spherogram is a Python module for dealing with the kind of planar
 diagrams that arise in 3-dimensional topology, such as link and
 Heegaard diagrams. It a component of the larger
-`SnapPy <http://snappy.computop.org>`_ project.  For some basic
+`SnapPy <https://snappy.computop.org>`_ project.  For some basic
 examples of using Spherogram to build links, 
-`see here <http://snappy.computop.org/spherogram.html>`_.  You can
+`see here <https://snappy.computop.org/spherogram.html>`_.  You can
 browse the `source code <https://github.com/3-manifolds/Spherogram>`_.
 
 Developed by 
@@ -22,8 +22,8 @@ with contributions from
 
 Also includes third-party libraries:
 
-* `Planarity by John Boyer <https://code.google.com/p/planarity/>`_
-* `Planarmap by Giles Schaeffer
+* `Planarity by John Boyer <https://github.com/graph-algorithms/edge-addition-planarity-suite>`_
+* `Planarmap by Gilles Schaeffer
   <http://www.lix.polytechnique.fr/Labo/Gilles.Schaeffer/PagesWeb/PlanarMap/>`_
 
   
@@ -33,6 +33,6 @@ License
 Copyright 2008-present by Marc Culler, Nathan Dunfield, and others.
 
 This code is released under the `GNU General Public License, version 2
-<http://www.gnu.org/licenses/gpl-2.0.txt>`_
+<https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>`_
 or (at your option) any later version as published by the Free
 Software Foundation. 


### PR DESCRIPTION
Gilles was misspelt as Giles.
Planarity has moved from Google Code to GitHub.
Use https for snappy.computop.org links.
Update GPL 2.0 link to https and new location.