### PR TITLE
fixes string representation for crossings in Torus knots

### DIFF
--- a/spherogram_src/links/links_base.py
+++ b/spherogram_src/links/links_base.py
@@ -153,7 +153,7 @@ class Crossing(object):
         other[0].adjacent[other[1]] = (self, i % 4)
 
     def __repr__(self):
-        return "%s" % self.label
+        return "%s" % (self.label, )
 
     def info(self):
         def format_adjacent(a):


### PR DESCRIPTION
For torus knots, a crossing label is a tuple of length 2, so
```
"%s" % self.label
```
fails.