### PR TITLE
Add auto import for snappy_16_knots

### DIFF
--- a/spherogram_src/links/links_base.py
+++ b/spherogram_src/links/links_base.py
@@ -45,11 +45,16 @@ def is_iterable(obj):
 DT_tables = snappy_manifolds.get_DT_tables()
 
 try:
-    import snappy_15_knots
+    import snappy_16_knots
     non_HT = [T for T in DT_tables if not T.name.startswith('HTLinkDTcodes')]
-    DT_tables = non_HT + snappy_15_knots.get_DT_tables()
+    DT_tables = non_HT + snappy_16_knots.get_DT_tables()
 except ImportError:
-    pass
+    try:
+        import snappy_15_knots
+        non_HT = [T for T in DT_tables if not T.name.startswith('HTLinkDTcodes')]
+        DT_tables = non_HT + snappy_15_knots.get_DT_tables()
+    except ImportError:
+        pass
 
 
 def lookup_DT_code_by_name(name):

--- a/spherogram_src/version.py
+++ b/spherogram_src/version.py
@@ -1,1 +1,1 @@
-version = '2.4.1a1'
+version = '2.4.2b'

--- a/spherogram_src/version.py
+++ b/spherogram_src/version.py
@@ -1,1 +1,1 @@
-version = '2.4.2b'
+version = '2.4.2b1'


### PR DESCRIPTION
This is to let Spherogram look for [snappy_16_knots](https://github.com/Shakugannotorch/snappy_16_knots) automatically and import the knot table from it. Since snappy_16_knots overwrites snappy_15_knots, I've made it so that it looks for snappy_15_knots only when import snappy_16_knots fails. 